### PR TITLE
chore: 🤖 psychedelic organisation scope

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@psychedelic:registry=https://npm.pkg.github.com

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@fleekhq/plug-inpage-provider",
-  "version": "1.0.1",
+  "name": "@psychedelic/plug-inpage-provider",
+  "version": "1.0.2-beta.1",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "jsnext:main": "dist/esm/index.js",
@@ -20,6 +20,9 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/FleekHQ/plug-inpage-provider.git"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/@psychedelic"
   },
   "keywords": [
     "package",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/FleekHQ/plug-inpage-provider.git"
+    "url": "git+https://github.com/psychedelic/plug-inpage-provider.git"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/@psychedelic"


### PR DESCRIPTION
# Why?

The repository should point to the @Psychedelic organisation in Github. Also, the package should be published under the organisation in the Github package registry.

# How?

- Modified the `.npmrc` to include the @Psychedelic organisation
- Modified the package.json to use the correct git repository location, ownership
- Bumped the package version to 1.0.2-beta.1
