### PR TITLE
feat 🎸 generic actor generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@psychedelic/plug-inpage-provider",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "jsnext:main": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
-  "sideEffects": false,  
+  "sideEffects": false,
   "scripts": {
     "build": "npm run clean && npm-run-all --parallel build:** && node ./scripts/add-package.js",
     "build:cjs": "tsc --module commonjs --target es6 --outDir ./dist",

--- a/src/Provider.ts
+++ b/src/Provider.ts
@@ -74,12 +74,13 @@ export default class Provider implements ProviderInterface {
   }
 
   public async createActor<T>({
-    agent,
     canisterId,
     interfaceFactory,
   }: CreateActor<T>): Promise<ActorSubclass<T>> {
+    if (!this.agent) throw Error('Oops! Agent initialisation required.');
+
     return Actor.createActor(interfaceFactory, {
-      agent,
+      agent: this.agent,
       canisterId,
     })
   }

--- a/src/Provider.ts
+++ b/src/Provider.ts
@@ -1,5 +1,6 @@
 import BrowserRPC from '@fleekhq/browser-rpc/dist/BrowserRPC';
-import { Agent, HttpAgent } from '@dfinity/agent';
+import { Agent, HttpAgent, Actor, ActorSubclass } from '@dfinity/agent';
+import { IDL } from '@dfinity/candid';
 import { Principal } from '@dfinity/principal';
 import getDomainMetadata from './utils/domain-metadata';
 import { PlugIdentity } from './identity';
@@ -25,6 +26,13 @@ interface SendICPTsArgs {
   opts?: SendOpts;
 }
 
+interface CreateActor<T> {
+  agent: HttpAgent;
+  actor: ActorSubclass<ActorSubclass<T>>;
+  canisterId: string;
+  interfaceFactory: IDL.InterfaceFactory;
+}
+
 export interface ProviderInterface {
   isConnected(): Promise<boolean>;
   principal: Principal;
@@ -32,6 +40,11 @@ export interface ProviderInterface {
   requestTransfer(args: SendICPTsArgs): Promise<bigint>;
   requestConnect(): Promise<any>;
   createAgent(whitelist: string[]): Promise<any>;
+  createActor<T>({
+    agent,
+    canisterId,
+    interfaceFactory,
+  }: CreateActor<T>): Promise<ActorSubclass<T>>;
   agent: Agent | null;
 };
 
@@ -58,6 +71,17 @@ export default class Provider implements ProviderInterface {
       host: "https://mainnet.dfinity.network",
     });
     return;
+  }
+
+  public async createActor<T>({
+    agent,
+    canisterId,
+    interfaceFactory,
+  }: CreateActor<T>): Promise<ActorSubclass<T>> {
+    return Actor.createActor(interfaceFactory, {
+      agent,
+      canisterId,
+    })
   }
 
   public async isConnected(): Promise<boolean> {

--- a/src/Provider.ts
+++ b/src/Provider.ts
@@ -41,7 +41,6 @@ export interface ProviderInterface {
   requestConnect(): Promise<any>;
   createAgent(whitelist: string[]): Promise<any>;
   createActor<T>({
-    agent,
     canisterId,
     interfaceFactory,
   }: CreateActor<T>): Promise<ActorSubclass<T>>;


### PR DESCRIPTION
## Why?

The end-user has to add the @dfinity/actor dependency and initialise separately to then wrap the ic.plug.agent.

The following PR, is a proposal for createActor in the Plug extension scope, which lets the user generate an actor through the provider API, without having to import @dfinity/actor dependencies separately or have the correct @dfinity/actor package version that is compatible with the one Plug uses.

## How?

- Created an dfx utility method createActor
- The createActor has 3 parameters (the agent, canisterId, and a interfaceFactory)
- Returns an Actor with the correct type definitions provided by the generic T


## Demo?


https://user-images.githubusercontent.com/236752/127313214-85ce0e54-e926-42e3-bc84-7d2517c8ef70.mp4

