### PR TITLE
fix 🐛 double publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "clean": "rimraf ./dist",
     "lint": "eslint --ext .js,.ts ./src/**",
     "lint:fix": "npm run lint -- --fix",
-    "test": "jest",
-    "publish": "npm run build && npm publish"
+    "test": "jest"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Why?

The publish script is not required, is reserved by npm, as it causes double publishing.

## How?

- Removed from package.json