### PR TITLE
fix: 🐛 whitelist handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psychedelic/plug-inpage-provider",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "jsnext:main": "dist/esm/index.js",

--- a/src/Provider.ts
+++ b/src/Provider.ts
@@ -97,7 +97,10 @@ export default class Provider implements ProviderInterface {
     });
   };
 
-  public async requestConnect({ whitelist, host }: RequestConnectParams = DEFAULT_REQUEST_CONNECT_ARGS): Promise<any> {
+  public async requestConnect({
+    whitelist = DEFAULT_REQUEST_CONNECT_ARGS.whitelist,
+    host = DEFAULT_REQUEST_CONNECT_ARGS.host,
+  }: RequestConnectParams): Promise<any> {
     const metadata = getDomainMetadata();
 
     const response = await this.clientRPC.call('requestConnect', [metadata, whitelist], {
@@ -122,7 +125,10 @@ export default class Provider implements ProviderInterface {
   };
 
   // Note: this will overwrite the current agent
-  public async createAgent({ whitelist, host }: CreateAgentParams = DEFAULT_REQUEST_CONNECT_ARGS) {
+  public async createAgent({
+    whitelist = DEFAULT_REQUEST_CONNECT_ARGS.whitelist,
+    host = DEFAULT_REQUEST_CONNECT_ARGS.host,
+  }: CreateAgentParams) {
     const metadata = getDomainMetadata();
     const publicKey = await this.clientRPC.call('getPublicKey', [metadata, whitelist], {
       timeout: 0,

--- a/src/Provider.ts
+++ b/src/Provider.ts
@@ -100,7 +100,7 @@ export default class Provider implements ProviderInterface {
   public async requestConnect({
     whitelist = DEFAULT_REQUEST_CONNECT_ARGS.whitelist,
     host = DEFAULT_REQUEST_CONNECT_ARGS.host,
-  }: RequestConnectParams): Promise<any> {
+  }: RequestConnectParams = DEFAULT_REQUEST_CONNECT_ARGS): Promise<any> {
     const metadata = getDomainMetadata();
 
     const response = await this.clientRPC.call('requestConnect', [metadata, whitelist], {
@@ -128,7 +128,7 @@ export default class Provider implements ProviderInterface {
   public async createAgent({
     whitelist = DEFAULT_REQUEST_CONNECT_ARGS.whitelist,
     host = DEFAULT_REQUEST_CONNECT_ARGS.host,
-  }: CreateAgentParams) {
+  }: CreateAgentParams = DEFAULT_REQUEST_CONNECT_ARGS) {
     const metadata = getDomainMetadata();
     const publicKey = await this.clientRPC.call('getPublicKey', [metadata, whitelist], {
       timeout: 0,

--- a/src/Provider.ts
+++ b/src/Provider.ts
@@ -20,7 +20,7 @@ export interface SendOpts {
 }
 
 // The amount in e8s (ICPs)
-interface SendICPTsArgs {
+interface RequestTransferParams {
   to: string;
   amount: bigint;
   opts?: SendOpts;
@@ -33,12 +33,26 @@ interface CreateActor<T> {
   interfaceFactory: IDL.InterfaceFactory;
 }
 
+interface RequestConnectParams {
+  whitelist: string[];
+  host: string;
+}
+
+interface CreateAgentParams extends RequestConnectParams {};
+
+const DEFAULT_HOST = "https://mainnet.dfinity.network";
+/* eslint-disable @typescript-eslint/no-unused-vars */
+const DEFAULT_REQUEST_CONNECT_ARGS: RequestConnectParams = {
+  whitelist: [],
+  host: DEFAULT_HOST,
+};
+
 export interface ProviderInterface {
   isConnected(): Promise<boolean>;
   requestBalance(accountId?: number): Promise<bigint>;
-  requestTransfer(args: SendICPTsArgs): Promise<bigint>;
-  requestConnect(whitelist?: string[], host?: string): Promise<any>;
-  createAgent(whitelist: string[], host?: string): Promise<any>;
+  requestTransfer(params: RequestTransferParams): Promise<bigint>;
+  requestConnect(params: RequestConnectParams): Promise<any>;
+  createAgent(params: CreateAgentParams): Promise<any>;
   createActor<T>({
     canisterId,
     interfaceFactory,


### PR DESCRIPTION
## Why?

The changes made for the whitelist and agent broke the base features. For example, `requestConnect` is not fulfilled, etc. The proposed changes mitigate the issues by enforcing the use of default types and expected validation against them, mainly through the calls to function with or without parameters.

## How?

- Use object type for parameters instead of csv in the function definitions
- Create new type definitions for RequestConnect, CreateAgent, etc
- Create default values, as constants which defaults on function call(s)

## Related

In the Plug repo, see https://github.com/Psychedelic/plug/pull/137