### PR TITLE
fix: skip whitelist checking on read_state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psychedelic/plug-inpage-provider",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "jsnext:main": "dist/esm/index.js",

--- a/src/identity.ts
+++ b/src/identity.ts
@@ -1,12 +1,17 @@
-import { SignIdentity, PublicKey, HttpAgentRequest } from '@dfinity/agent';
-import { BinaryBlob, blobFromBuffer, DerEncodedBlob } from '@dfinity/candid';
-import { Principal } from '@dfinity/principal';
-import { Buffer } from 'buffer/';
-import { requestIdOf } from './utils/request_id';
+import {
+  SignIdentity,
+  PublicKey,
+  HttpAgentRequest,
+  ReadRequestType,
+} from "@dfinity/agent";
+import { BinaryBlob, blobFromBuffer, DerEncodedBlob } from "@dfinity/candid";
+import { Principal } from "@dfinity/principal";
+import { Buffer } from "buffer/";
+import { requestIdOf } from "./utils/request_id";
 
 type SignCb = (payload: ArrayBuffer) => Promise<ArrayBuffer>;
 
-const domainSeparator = Buffer.from(new TextEncoder().encode('\x0Aic-request'));
+const domainSeparator = Buffer.from(new TextEncoder().encode("\x0Aic-request"));
 interface SerializedPublicKey {
   rawKey: {
     type: string;
@@ -20,13 +25,20 @@ interface SerializedPublicKey {
 export class PlugIdentity extends SignIdentity {
   private publicKey: PublicKey;
   private whitelist: string[];
-  constructor(publicKey: SerializedPublicKey, private signCb: SignCb, whitelist: string[]) {
+  constructor(
+    publicKey: SerializedPublicKey,
+    private signCb: SignCb,
+    whitelist: string[]
+  ) {
     super();
-    this.publicKey = { ...publicKey, toDer: () => publicKey.derKey?.data ?? publicKey.derKey };
+    this.publicKey = {
+      ...publicKey,
+      toDer: () => publicKey.derKey?.data ?? publicKey.derKey,
+    };
     this.signCb = signCb;
     this.whitelist = whitelist || [];
   }
-  
+
   getPublicKey(): PublicKey {
     return this.publicKey;
   }
@@ -48,28 +60,39 @@ export class PlugIdentity extends SignIdentity {
    * anything, but must be serializable to CBOR.
    * @param request - internet computer request to transform
    */
-   public async transformRequest(request: HttpAgentRequest): Promise<unknown> {
+  public async transformRequest(request: HttpAgentRequest): Promise<unknown> {
     const { body, ...fields } = request;
 
-    const canister = body?.canister_id instanceof Principal ? body?.canister_id : Principal.fromUint8Array(body?.canister_id?._arr);
-    if (!this.whitelist.some(id => id === canister.toString())){
-      throw new Error(`Request failed:\n` +
-                `  Code: 401\n` +
-                `  Body: Plug Identity is not allowed to make requests to canister Id ${canister.toString()}`);
+    const canister =
+      body?.canister_id instanceof Principal
+        ? body?.canister_id
+        : Principal.fromUint8Array(body?.canister_id?._arr);
+
+    if (
+      body.request_type !== ReadRequestType.ReadState &&
+      !this.whitelist.some((id) => id === canister.toString())
+    ) {
+      throw new Error(
+        `Request failed:\n` +
+          `  Code: 401\n` +
+          `  Body: Plug Identity is not allowed to make requests to canister Id ${canister.toString()}`
+      );
     }
-  
+
     const requestId = await requestIdOf(body);
-    const sender_sig = await this.sign(blobFromBuffer(Buffer.concat([domainSeparator, requestId])))
+    const sender_sig = await this.sign(
+      blobFromBuffer(Buffer.concat([domainSeparator, requestId]))
+    );
 
     const transformedResponse = {
       ...fields,
       body: {
         content: {
           ...body,
-          canister_id: canister
+          canister_id: canister,
         },
         sender_pubkey: this.getPublicKey().toDer(),
-        sender_sig
+        sender_sig,
       },
     };
     return transformedResponse;

--- a/src/identity.ts
+++ b/src/identity.ts
@@ -87,10 +87,7 @@ export class PlugIdentity extends SignIdentity {
     const transformedResponse = {
       ...fields,
       body: {
-        content: {
-          ...body,
-          canister_id: canister,
-        },
+        content: body,
         sender_pubkey: this.getPublicKey().toDer(),
         sender_sig,
       },


### PR DESCRIPTION
# fix: skip whitelist checking on read_state

## Summary

[Agent-JS code](https://github.com/Psychedelic/agent-js-clone/blob/90b073dc735bfae9f3b1c7fc537bd97347c5cc68/packages/agent/src/agent/http/index.ts#L291-L312) is not providing caniser_id on read_state request, so we have to skip the  check of it on the transform request