### PR TITLE
feat: 🎸 get management canister

### DIFF
--- a/src/Provider.ts
+++ b/src/Provider.ts
@@ -201,7 +201,9 @@ export default class Provider implements ProviderInterface {
   }
 
   public async getManagementCanister() {
-    if (!this.agent || !this.identity) return;
+    if (!this.agent || !this.identity) {
+      throw Error('Oops! Agent initialization or identity required.')
+    };
 
     return Actor.createActor(managementCanisterIdlFactory, {
       agent: this.agent,

--- a/src/Provider.ts
+++ b/src/Provider.ts
@@ -76,15 +76,11 @@ export default class Provider implements ProviderInterface {
   // @ts-ignore
   public principal: Principal;
   private clientRPC: BrowserRPC;
-  private identity: PlugIdentity | null;
-  private requestedHost: string | null;
 
   constructor(clientRPC: BrowserRPC) {
     this.clientRPC = clientRPC;
     this.clientRPC.start();
     this.agent = null;
-    this.identity = null;
-    this.requestedHost = null;
   }
 
   public deleteAgent() {
@@ -136,9 +132,6 @@ export default class Provider implements ProviderInterface {
       identity,
       host,
     });
-
-    this.identity = identity;
-    this.requestedHost = host;
 
     return !!this.agent;
   };
@@ -201,8 +194,8 @@ export default class Provider implements ProviderInterface {
   }
 
   public async getManagementCanister() {
-    if (!this.agent || !this.identity) {
-      throw Error('Oops! Agent initialization or identity required.')
+    if (!this.agent) {
+      throw Error('Oops! Agent initialization required.')
     };
 
     return Actor.createActor(managementCanisterIdlFactory, {

--- a/src/Provider.ts
+++ b/src/Provider.ts
@@ -3,6 +3,7 @@ import { Agent, HttpAgent, Actor, ActorSubclass } from '@dfinity/agent';
 import { IDL } from '@dfinity/candid';
 import { Principal } from '@dfinity/principal';
 import getDomainMetadata from './utils/domain-metadata';
+import { managementCanisterIdlFactory } from './utils/ic-management-api';
 import { PlugIdentity } from './identity';
 
 export interface RequestConnectInput {
@@ -73,6 +74,7 @@ export default class Provider implements ProviderInterface {
   // @ts-ignore
   public principal: Principal;
   private clientRPC: BrowserRPC;
+
   constructor(clientRPC: BrowserRPC) {
     this.clientRPC = clientRPC;
     this.clientRPC.start();
@@ -189,5 +191,14 @@ export default class Provider implements ProviderInterface {
       timeout: 0,
       target: "",
     })
+  }
+
+  public async getManagementCanister() {
+    if (!this.agent) return;
+
+    return Actor.createActor(managementCanisterIdlFactory, {
+      agent: this.agent,
+      canisterId: Principal.fromHex(''),
+    });
   }
 };

--- a/src/Provider.ts
+++ b/src/Provider.ts
@@ -201,12 +201,10 @@ export default class Provider implements ProviderInterface {
   }
 
   public async getManagementCanister() {
-    if (!this.agent || !this.identity || !this.requestedHost) return;
-
-    const agent = this.agent;
+    if (!this.agent || !this.identity) return;
 
     return Actor.createActor(managementCanisterIdlFactory, {
-      agent,
+      agent: this.agent,
       canisterId: managementCanisterPrincipal,
       ...{
         callTransform: transformOverrideHandler,

--- a/src/Provider.ts
+++ b/src/Provider.ts
@@ -33,6 +33,7 @@ interface CreateActor<T> {
   actor: ActorSubclass<ActorSubclass<T>>;
   canisterId: string;
   interfaceFactory: IDL.InterfaceFactory;
+  effectiveCanisterId?: Principal;
 }
 
 interface RequestConnectParams {
@@ -60,6 +61,7 @@ export interface ProviderInterface {
   createActor<T>({
     canisterId,
     interfaceFactory,
+    effectiveCanisterId,
   }: CreateActor<T>): Promise<ActorSubclass<T>>;
   agent: Agent | null;
   createAgent(params: CreateAgentParams): Promise<boolean>;
@@ -85,12 +87,14 @@ export default class Provider implements ProviderInterface {
   public async createActor<T>({
     canisterId,
     interfaceFactory,
+    effectiveCanisterId,
   }: CreateActor<T>): Promise<ActorSubclass<T>> {
     if (!this.agent) throw Error('Oops! Agent initialization required.');
 
     return Actor.createActor(interfaceFactory, {
       agent: this.agent,
       canisterId,
+      effectiveCanisterId,
     })
   }
 

--- a/src/Provider.ts
+++ b/src/Provider.ts
@@ -38,7 +38,6 @@ interface CreateActor<T> {
   actor: ActorSubclass<ActorSubclass<T>>;
   canisterId: string;
   interfaceFactory: IDL.InterfaceFactory;
-  effectiveCanisterId?: Principal;
 }
 
 interface RequestConnectParams {
@@ -66,7 +65,6 @@ export interface ProviderInterface {
   createActor<T>({
     canisterId,
     interfaceFactory,
-    effectiveCanisterId,
   }: CreateActor<T>): Promise<ActorSubclass<T>>;
   agent: Agent | null;
   createAgent(params: CreateAgentParams): Promise<boolean>;
@@ -97,14 +95,12 @@ export default class Provider implements ProviderInterface {
   public async createActor<T>({
     canisterId,
     interfaceFactory,
-    effectiveCanisterId,
   }: CreateActor<T>): Promise<ActorSubclass<T>> {
     if (!this.agent) throw Error('Oops! Agent initialization required.');
 
     return Actor.createActor(interfaceFactory, {
       agent: this.agent,
       canisterId,
-      effectiveCanisterId,
     })
   }
 

--- a/src/utils/ic-management-api.ts
+++ b/src/utils/ic-management-api.ts
@@ -1,0 +1,107 @@
+export const managementCanisterIdlFactory = ({ IDL }) => {
+  const canister_id = IDL.Principal;
+  const definite_canister_settings = IDL.Record({
+    'freezing_threshold' : IDL.Nat,
+    'controllers' : IDL.Vec(IDL.Principal),
+    'memory_allocation' : IDL.Nat,
+    'compute_allocation' : IDL.Nat,
+  });
+  const canister_settings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat),
+    'controllers' : IDL.Opt(IDL.Vec(IDL.Principal)),
+    'memory_allocation' : IDL.Opt(IDL.Nat),
+    'compute_allocation' : IDL.Opt(IDL.Nat),
+  });
+  const wasm_module = IDL.Vec(IDL.Nat8);
+  return IDL.Service({
+    'canister_status' : IDL.Func(
+        [IDL.Record({ 'canister_id' : canister_id })],
+        [
+          IDL.Record({
+            'status' : IDL.Variant({
+              'stopped' : IDL.Null,
+              'stopping' : IDL.Null,
+              'running' : IDL.Null,
+            }),
+            'memory_size' : IDL.Nat,
+            'cycles' : IDL.Nat,
+            'settings' : definite_canister_settings,
+            'module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+          }),
+        ],
+        [],
+      ),
+    'create_canister' : IDL.Func(
+        [IDL.Record({ 'settings' : IDL.Opt(canister_settings) })],
+        [IDL.Record({ 'canister_id' : canister_id })],
+        [],
+      ),
+    'delete_canister' : IDL.Func(
+        [IDL.Record({ 'canister_id' : canister_id })],
+        [],
+        [],
+      ),
+    'deposit_cycles' : IDL.Func(
+        [IDL.Record({ 'canister_id' : canister_id })],
+        [],
+        [],
+      ),
+    'install_code' : IDL.Func(
+        [
+          IDL.Record({
+            'arg' : IDL.Vec(IDL.Nat8),
+            'wasm_module' : wasm_module,
+            'mode' : IDL.Variant({
+              'reinstall' : IDL.Null,
+              'upgrade' : IDL.Null,
+              'install' : IDL.Null,
+            }),
+            'canister_id' : canister_id,
+          }),
+        ],
+        [],
+        [],
+      ),
+    'provisional_create_canister_with_cycles' : IDL.Func(
+        [
+          IDL.Record({
+            'settings' : IDL.Opt(canister_settings),
+            'amount' : IDL.Opt(IDL.Nat),
+          }),
+        ],
+        [IDL.Record({ 'canister_id' : canister_id })],
+        [],
+      ),
+    'provisional_top_up_canister' : IDL.Func(
+        [IDL.Record({ 'canister_id' : canister_id, 'amount' : IDL.Nat })],
+        [],
+        [],
+      ),
+    'raw_rand' : IDL.Func([], [IDL.Vec(IDL.Nat8)], []),
+    'start_canister' : IDL.Func(
+        [IDL.Record({ 'canister_id' : canister_id })],
+        [],
+        [],
+      ),
+    'stop_canister' : IDL.Func(
+        [IDL.Record({ 'canister_id' : canister_id })],
+        [],
+        [],
+      ),
+    'uninstall_code' : IDL.Func(
+        [IDL.Record({ 'canister_id' : canister_id })],
+        [],
+        [],
+      ),
+    'update_settings' : IDL.Func(
+        [
+          IDL.Record({
+            'canister_id' : IDL.Principal,
+            'settings' : canister_settings,
+          }),
+        ],
+        [],
+        [],
+      ),
+  });
+};

--- a/src/utils/ic-management-api.ts
+++ b/src/utils/ic-management-api.ts
@@ -1,3 +1,6 @@
+import { Principal } from '@dfinity/principal';
+import { CallConfig } from '@dfinity/agent';
+
 export const managementCanisterIdlFactory = ({ IDL }) => {
   const canister_id = IDL.Principal;
   const definite_canister_settings = IDL.Record({
@@ -104,4 +107,30 @@ export const managementCanisterIdlFactory = ({ IDL }) => {
         [],
       ),
   });
+};
+
+export interface TransformArguments {
+  canister_id: String,
+}
+
+export const managementCanisterPrincipal = Principal.fromHex('');
+
+export const transformOverrideHandler = (
+  methodName: string,
+  args: TransformArguments[],
+  callConfig: CallConfig,
+) => {
+  let overridable = {
+    effectiveCanisterId: managementCanisterPrincipal,
+  }
+
+  if (!Array.isArray(args) || !args.length) return overridable;
+
+  if (args[0].hasOwnProperty('canister_id') && args[0].canister_id) {
+    overridable = {
+      effectiveCanisterId: Principal.from(args[0].canister_id),
+    }
+  }
+
+  return overridable;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -303,9 +303,9 @@
     minimist "^1.2.0"
 
 "@dfinity/agent@^0.9.2":
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@dfinity/agent/-/agent-0.9.2.tgz#3df764bfa308a4fba7e0f42e1ffa45bd1c2a406d"
-  integrity sha512-nxYagdY1zAIimgff/NbOGs4pfgNlSWw/oBR/pIHfJMIdklGGzlU69wnyqRJCL9yUCO3I/0bbxeWGzaV7aVabIw==
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/@dfinity/agent/-/agent-0.9.3.tgz#e49f07d6749e534c4c30aa2df2bba59e3fa9570f"
+  integrity sha512-vR0t5Uf+srbUHTdGunJxek3a4jCmBKU+B2yYEX0/aSGQfJmEf5X5snuNcnrIDOCfHeK7uxmOqs65BdI8Lhn4fg==
   dependencies:
     base64-arraybuffer "^0.2.0"
     bignumber.js "^9.0.0"
@@ -316,17 +316,17 @@
     simple-cbor "^0.4.1"
 
 "@dfinity/candid@^0.9.2":
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@dfinity/candid/-/candid-0.9.2.tgz#2c2562d09aeab505d918fbce11a2f9b246abf094"
-  integrity sha512-h8fzslfP5wiZLQoaAGQEEx7naaOWmfSrL8cfHRk98fiy5m3SnoQrAkIQVLr5l3tq8zFosIyYov+47lgxMTBRUA==
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/@dfinity/candid/-/candid-0.9.3.tgz#96b2a5339da634ccc5546a0560f48f5ceef70dfe"
+  integrity sha512-VMovKFrExqN0mwcn1/aut4Ou4cA9IA2+QrBjV+Ro4eVCpVvGpVRqn4jizlV9QnJjcuEBG1yImIG5RKMdZ2ejQQ==
   dependencies:
     buffer "^6.0.3"
     buffer-pipe "^0.0.4"
 
 "@dfinity/principal@^0.9.2":
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@dfinity/principal/-/principal-0.9.2.tgz#b59841258fa39bdefaded51d5d37cc738c5dd19b"
-  integrity sha512-YtxM+BSYS1FlLOz/SYPyvniw1j0UbMnM99IueVLaLEgIi76gRYxV9kTewbzc57DqyCcBquvn+doZpMHHqHiuUA==
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/@dfinity/principal/-/principal-0.9.3.tgz#52e4980bac8dd35e7a6bb2564bea89df97383e06"
+  integrity sha512-DSL3b/gGm+f57+3XkFjlK4DigtKXe9MVO8UYXDQWkVIhy0UF1KYjRNGs6awc1GTQoOTxeQ8UTFwXuvnEvJ1hpQ==
 
 "@eslint/eslintrc@^0.4.1":
   version "0.4.1"


### PR DESCRIPTION
## Why?

On the client-side, allow the ability to get a canister status that the user identity has control over.

⚠️ This is related to https://github.com/Psychedelic/fleek-ooo/pull/112 that uses this one has a dependency (e.g. the Plug Extension uses this feature and is utilized during dev of https://github.com/Psychedelic/fleek-ooo/pull/112). This should only be merged after confirmation that is indeed useful

## How?

- Extends the Provider, by providing a get management canister actor
- A transformer to override the effective canister id
- Provide the IDL Factory
- Uses latest Dfinity packages on 0.9.x

## Tickets?

- [ch23935](https://app.shortcut.com/terminalsystems/story/23935/add-support-for-management-canister-to-plug-controller)

## Demo?

```js
    // The CanisterID which the Plug wallet of a principal id has control
    const canisterId = 'f2aaj-ayaaa-aaaah-aapgq-cai';

    // Provide the whitelist, including the management address
    await window.ic.plug.requestConnect({
      whitelist: [canisterId, 'aaaaa-aa'],
    });

    // The getter for the management canister actor instance
    const management = await window.ic.plug.getManagementCanister();

    console.log('[debug] management: ', management);

    // Request the `canister_status` as defined in the IDL of the IC Management API
    const data = await management.canister_status({
      canister_id: Principal.from(canisterId),
    });

    console.log('[debug] data: ', data);
```

<img width="887" alt="Screenshot 2021-09-15 at 15 34 03" src="https://user-images.githubusercontent.com/236752/133453564-1a61792f-8c0f-4e53-930b-83f7e42b0ce1.png">

## Build?

A Chrome extension version:

[chrome.zip](https://github.com/Psychedelic/plug-inpage-provider/files/7170960/chrome.zip)

## Test playground?

https://github.com/Psychedelic/test-ic-management-api