### PR TITLE
fix: create wrapped actor to modify args an support old principal

### DIFF
--- a/src/Provider.ts
+++ b/src/Provider.ts
@@ -117,7 +117,8 @@ const createWrappedActorClass = (
       methodNamesArr.forEach((methodName) => {
         const handlerWrapped = (...args: unknown[]) => {
           const scapedArgs = args.map((arg) => {
-            return (arg as OldPrincipal)._isPrincipal
+            const wrappedArg = arg as OldPrincipal;
+            return wrappedArg._isPrincipal && wrappedArg._blob
               ? Principal.fromUint8Array((arg as OldPrincipal)._blob)
               : arg;
           });

--- a/src/Provider.ts
+++ b/src/Provider.ts
@@ -53,6 +53,13 @@ interface RequestBurnXTCParams {
   amount: bigint;
 }
 
+type WrappedActorConstructor = new () => ActorSubclass;
+
+interface OldPrincipal {
+  _blob: Uint8Array;
+  _isPrincipal: boolean;
+}
+
 const DEFAULT_HOST = "https://mainnet.dfinity.network";
 /* eslint-disable @typescript-eslint/no-unused-vars */
 const DEFAULT_REQUEST_CONNECT_ARGS: RequestConnectParams = {
@@ -91,12 +98,6 @@ const signFactory =
     });
     return new Uint8Array(Object.values(res));
   };
-type WrappedActorConstructor = new () => ActorSubclass;
-
-interface OldPrincipal {
-  _blob: Uint8Array;
-  _isPrincipal: boolean;
-}
 
 const createWrappedActorClass = (
   agent: Agent,


### PR DESCRIPTION
# fix: create wrapped actor to modify args an support old principal

## Summary

If the page try to use old Principal with the new inpage, it gonna break because of this [issue](https://github.com/dfinity/agent-js/issues/497). So I create a wrapper to modify arguments and add support

I've already create a pr to fix this on the dfinity library but I dont know how much time gonna take
https://github.com/dfinity/agent-js/pull/498