### PR TITLE
Add root key fetching if host is not default

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 import packageJSON from "../package.json";
 
-export const IC_MAINNET_URLS = ['https://mainnet.dfinity.network', 'ic0.app'];
+export const PLUG_PROXY_HOST = 'https://mainnet.plugwallet.ooo/';
+export const IC_MAINNET_URLS = ['https://mainnet.dfinity.network', 'ic0.app', PLUG_PROXY_HOST];
 
 export const versions = {
   extension: "0.4.5",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,7 @@
 import packageJSON from "../package.json";
 
+export const IC_MAINNET_URLS = ['https://mainnet.dfinity.network', 'ic0.app'];
+
 export const versions = {
   extension: "0.4.5",
   provider: packageJSON.version,

--- a/src/utils/agent.ts
+++ b/src/utils/agent.ts
@@ -42,10 +42,14 @@ export const createAgent = async (
     whitelist
   );
 
-  return new HttpAgent({
+  const agent = new HttpAgent({
     identity,
     host,
   });
+  if (host !== DEFAULT_CREATE_AGENT_ARGS.host) {
+    await agent.fetchRootKey();
+  }
+  return agent;
 };
 
 export const createActor = async <T>(

--- a/src/utils/agent.ts
+++ b/src/utils/agent.ts
@@ -1,4 +1,5 @@
 import { HttpAgent, Actor, ActorSubclass } from "@dfinity/agent";
+import { IC_MAINNET_URLS } from "../constants";
 
 import { PlugIdentity } from "../identity";
 import { signFactory } from "./sign";
@@ -13,7 +14,7 @@ interface CreateAgentParamsFixed {
   host: string;
 }
 
-const DEFAULT_HOST = "https://mainnet.dfinity.network";
+const DEFAULT_HOST = IC_MAINNET_URLS[0];
 /* eslint-disable @typescript-eslint/no-unused-vars */
 const DEFAULT_CREATE_AGENT_ARGS: CreateAgentParamsFixed = {
   whitelist: [],
@@ -46,7 +47,7 @@ export const createAgent = async (
     identity,
     host,
   });
-  if (host !== DEFAULT_CREATE_AGENT_ARGS.host) {
+  if (!IC_MAINNET_URLS.includes(host)) {
     await agent.fetchRootKey();
   }
   return agent;


### PR DESCRIPTION
## Summary
In order to validate certificates when running a test environment, `fetchRootKey` is required after agent creation.