### PR TITLE
Features: Principal and Account ID as strings. Remove value from balance call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psychedelic/plug-inpage-provider",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "main": "dist/src/index.js",
   "module": "dist/esm/src/index.js",
   "jsnext:main": "dist/esm/src/index.js",
@@ -59,6 +59,8 @@
     "@dfinity/candid": "0.9.3",
     "@dfinity/principal": "0.9.3",
     "@fleekhq/browser-rpc": "^2.0.3",
+    "buffer-crc32": "^0.2.13",
+    "crypto-js": "^4.1.1",
     "json-bigint": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psychedelic/plug-inpage-provider",
-  "version": "1.6.5",
+  "version": "2.0.0",
   "main": "dist/src/index.js",
   "module": "dist/esm/src/index.js",
   "jsnext:main": "dist/esm/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psychedelic/plug-inpage-provider",
-  "version": "2.0.0",
+  "version": "1.7.0",
   "main": "dist/src/index.js",
   "module": "dist/esm/src/index.js",
   "jsnext:main": "dist/esm/src/index.js",

--- a/src/Provider/index.ts
+++ b/src/Provider/index.ts
@@ -35,6 +35,29 @@ export default class Provider implements ProviderInterface {
     this.versions = versions;
   }
 
+  public async init() {
+    const metadata = getDomainMetadata();
+    const isConnected = await this.callClientRPC({
+      handler: "isConnected",
+      args: [metadata.url],
+      config: {
+        timeout: 0,
+        target: "",
+      },
+    });
+    if (isConnected) {
+      this.agent = await createAgent(
+        this.clientRPC,
+        metadata,
+        { whitelist: [] },
+        this.idls
+      );
+      const principal = await this.agent.getPrincipal();
+      this.principal = principal.toString();
+      this.accountId = await getAccountId(principal);
+    }
+  }
+
   private async callClientRPC({ handler, args, config }): Promise<any> {
     const metadata = getDomainMetadata();
 

--- a/src/Provider/index.ts
+++ b/src/Provider/index.ts
@@ -1,111 +1,37 @@
 import BrowserRPC from "@fleekhq/browser-rpc/dist/BrowserRPC";
-import { Agent, HttpAgent, Actor, ActorSubclass } from "@dfinity/agent";
-import { IDL } from "@dfinity/candid";
+import { Agent, Actor, ActorSubclass } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 
-import getDomainMetadata from "./utils/domain-metadata";
+import getDomainMetadata from "../utils/domain-metadata";
 import {
   managementCanisterIdlFactory,
   managementCanisterPrincipal,
   transformOverrideHandler,
-} from "./utils/ic-management-api";
-import { versions } from "./constants";
+} from "../utils/ic-management-api";
+import { versions } from "../constants";
 import {
   getArgTypes,
   ArgsTypesOfCanister,
   getSignInfoFromTransaction,
-} from "./utils/sign";
-import { createActor, createAgent, CreateAgentParams } from "./utils/agent";
-import { recursiveParseBigint } from "./utils/bigint";
+} from "../utils/sign";
+import { createActor, createAgent, CreateAgentParams } from "../utils/agent";
+import { recursiveParseBigint } from "../utils/bigint";
+import { CreateActor, ProviderInterface, ProviderInterfaceVersions, RequestBurnXTCParams, RequestConnectParams, RequestTransferParams, Transaction, TransactionPrevResponse } from "./interfaces";
+import { getAccountId } from "../utils/account";
 
-export interface TransactionPrevResponse {
-  transactionIndex: number;
-  response: any;
-}
-
-export interface Transaction<SuccessResponse = unknown[]> {
-  idl: IDL.InterfaceFactory;
-  canisterId: string;
-  methodName: string;
-  args: (responses?: TransactionPrevResponse[]) => any[] | any[];
-  onSuccess: (res: SuccessResponse) => Promise<any>;
-  onFail: (err: any, responses?: TransactionPrevResponse[]) => Promise<void>;
-}
-
-export interface RequestConnectInput {
-  canisters?: Principal[];
-  timeout?: number;
-}
-
-export interface TimeStamp {
-  timestamp_nanos: bigint;
-}
-
-export interface SendOpts {
-  fee?: bigint;
-  memo?: bigint;
-  from_subaccount?: number;
-  created_at_time?: TimeStamp;
-}
-
-// The amount in e8s (ICPs)
-interface RequestTransferParams {
-  to: string;
-  amount: bigint;
-  opts?: SendOpts;
-}
-
-interface CreateActor<T> {
-  agent: HttpAgent;
-  actor: ActorSubclass<ActorSubclass<T>>;
-  canisterId: string;
-  interfaceFactory: IDL.InterfaceFactory;
-}
-
-interface RequestBurnXTCParams {
-  to: string;
-  amount: bigint;
-}
-
-interface RequestConnectParams extends CreateAgentParams {
-  timeout?: number;
-}
-
-export interface ProviderInterfaceVersions {
-  provider: string;
-  extension: string;
-}
-
-export interface ProviderInterface {
-  isConnected(): Promise<boolean>;
-  disconnect(): Promise<void>;
-  batchTransactions(transactions: Transaction[]): Promise<boolean>;
-  requestBalance(accountId?: number | null): Promise<bigint>;
-  requestTransfer(params: RequestTransferParams): Promise<bigint>;
-  requestConnect(params: RequestConnectParams): Promise<any>;
-  createActor<T>({
-    canisterId,
-    interfaceFactory,
-  }: CreateActor<T>): Promise<ActorSubclass<T>>;
-  agent: Agent | null;
-  createAgent(params: CreateAgentParams): Promise<boolean>;
-  requestBurnXTC(params: RequestBurnXTCParams): Promise<any>;
-  versions: ProviderInterfaceVersions;
-  getPrincipal: () => Promise<Principal>;
-}
 
 export default class Provider implements ProviderInterface {
-  public agent: Agent | null;
+  public agent?: Agent;
   public versions: ProviderInterfaceVersions;
   // @ts-ignore
-  public principal: Principal;
+  public principal: string;
+  public accountId?: string;
   private clientRPC: BrowserRPC;
   private idls: ArgsTypesOfCanister = {};
 
   constructor(clientRPC: BrowserRPC) {
     this.clientRPC = clientRPC;
     this.clientRPC.start();
-    this.agent = null;
     this.versions = versions;
   }
 
@@ -138,7 +64,7 @@ export default class Provider implements ProviderInterface {
   }
 
   public deleteAgent() {
-    this.agent = null;
+    this.agent = undefined;
     return;
   }
 
@@ -160,10 +86,11 @@ export default class Provider implements ProviderInterface {
   }
 
   // Todo: Add whole getPrincipal flow on main plug repo in case this has been deleted.
-  public async getPrincipal(): Promise<Principal> {
+  public async getPrincipal({ asString } = { asString: false }): Promise<Principal | string> {
     const metadata = getDomainMetadata();
-    if (this.principal) {
-      return this.principal;
+    const principal = this.principal;
+    if (principal) {
+      return asString ? principal.toString() : Principal.from(principal);
     } else {
       const response = await this.callClientRPC({
         handler: "getPrincipal",
@@ -174,11 +101,11 @@ export default class Provider implements ProviderInterface {
         },
       });
 
-      if (response && typeof response === "string") {
-        return Principal.from(response);
+      if (response && asString) {
+        return response.toString();
       }
 
-      return response;
+      return Principal.from(response);
     }
   }
 
@@ -221,17 +148,16 @@ export default class Provider implements ProviderInterface {
       },
     });
 
-    if (!whitelist || !Array.isArray(whitelist) || !whitelist.length)
-      return publicKey;
     this.agent = await createAgent(
       this.clientRPC,
       metadata,
       { whitelist, host },
       this.idls
-    );
-
-    this.principal = await this.agent.getPrincipal();
-
+      );
+    const principal = await this.agent.getPrincipal();
+    this.principal = principal.toString();
+    this.accountId = await getAccountId(principal);
+      
     return publicKey;
   }
 
@@ -254,7 +180,7 @@ export default class Provider implements ProviderInterface {
   public async requestBalance(accountId = null): Promise<bigint> {
     const metadata = getDomainMetadata();
 
-    return await this.callClientRPC({
+    const balances = await this.callClientRPC({
       handler: "requestBalance",
       args: [metadata, accountId],
       config: {
@@ -262,6 +188,11 @@ export default class Provider implements ProviderInterface {
         target: "",
       },
     });
+    return balances.map(balance => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { value, ...rest } = balance;
+      return rest;
+    })
   }
 
   public async requestTransfer(params: RequestTransferParams): Promise<bigint> {

--- a/src/Provider/interfaces.ts
+++ b/src/Provider/interfaces.ts
@@ -1,0 +1,83 @@
+import { Agent, HttpAgent, ActorSubclass } from "@dfinity/agent";
+import { IDL } from "@dfinity/candid";
+import { Principal } from "@dfinity/principal";
+
+import { CreateAgentParams } from "../utils/agent";
+
+export interface TransactionPrevResponse {
+  transactionIndex: number;
+  response: any;
+}
+  
+export interface Transaction<SuccessResponse = unknown[]> {
+  idl: IDL.InterfaceFactory;
+  canisterId: string;
+  methodName: string;
+  args: (responses?: TransactionPrevResponse[]) => any[] | any[];
+  onSuccess: (res: SuccessResponse) => Promise<any>;
+  onFail: (err: any, responses?: TransactionPrevResponse[]) => Promise<void>;
+}
+  
+export interface RequestConnectInput {
+  canisters?: Principal[];
+  timeout?: number;
+}
+  
+export interface TimeStamp {
+  timestamp_nanos: bigint;
+}
+  
+export interface SendOpts {
+  fee?: bigint;
+  memo?: bigint;
+  from_subaccount?: number;
+  created_at_time?: TimeStamp;
+}
+  
+  // The amount in e8s (ICPs)
+export interface RequestTransferParams {
+  to: string;
+  amount: bigint;
+  opts?: SendOpts;
+}
+  
+export interface CreateActor<T> {
+  agent: HttpAgent;
+  actor: ActorSubclass<ActorSubclass<T>>;
+  canisterId: string;
+  interfaceFactory: IDL.InterfaceFactory;
+}
+  
+export interface RequestBurnXTCParams {
+  to: string;
+  amount: bigint;
+}
+  
+export interface RequestConnectParams extends CreateAgentParams {
+  timeout?: number;
+}
+  
+export interface ProviderInterfaceVersions {
+  provider: string;
+  extension: string;
+}
+  
+export interface ProviderInterface {
+  isConnected(): Promise<boolean>;
+  disconnect(): Promise<void>;
+  batchTransactions(transactions: Transaction[]): Promise<boolean>;
+  requestBalance(accountId?: number | null): Promise<bigint>;
+  requestTransfer(params: RequestTransferParams): Promise<bigint>;
+  requestConnect(params: RequestConnectParams): Promise<any>;
+  createActor<T>({
+    canisterId,
+    interfaceFactory,
+  }: CreateActor<T>): Promise<ActorSubclass<T>>;
+  createAgent(params: CreateAgentParams): Promise<boolean>;
+  requestBurnXTC(params: RequestBurnXTCParams): Promise<any>;
+  getPrincipal: () => Promise<Principal | string>;
+  versions: ProviderInterfaceVersions;
+  agent?: Agent | null;
+  principal?: string;
+  accountId?: string;
+}

--- a/src/utils/account.ts
+++ b/src/utils/account.ts
@@ -1,0 +1,43 @@
+import CryptoJS from 'crypto-js';
+import { Principal } from '@dfinity/principal';
+
+import {
+  byteArrayToWordArray,
+  generateChecksum,
+  wordArrayToByteArray,
+} from './crypto';
+
+// Dfinity Account separator
+const ACCOUNT_DOMAIN_SEPERATOR = '\x0Aaccount-id';
+
+// Subaccounts are arbitrary 32-byte values.
+const SUB_ACCOUNT_ZERO = Buffer.alloc(32);
+
+/*
+    Used dfinity/keysmith/account/account.go as a base for the ID generation
+*/
+export const getAccountId = (
+    principal: Principal,
+    subAccount?: number
+  ): string => {
+    const sha = CryptoJS.algo.SHA224.create();
+    sha.update(ACCOUNT_DOMAIN_SEPERATOR); // Internally parsed with UTF-8, like go does
+    sha.update(byteArrayToWordArray(principal.toUint8Array()));
+    const subBuffer = Buffer.from(SUB_ACCOUNT_ZERO);
+    if (subAccount) {
+      subBuffer.writeUInt32BE(subAccount);
+    }
+    sha.update(byteArrayToWordArray(subBuffer));
+    const hash = sha.finalize();
+  
+    /// While this is backed by an array of length 28, it's canonical representation
+    /// is a hex string of length 64. The first 8 characters are the CRC-32 encoded
+    /// hash of the following 56 characters of hex. Both, upper and lower case
+    /// characters are valid in the input string and can even be mixed.
+    /// [ic/rs/rosetta-api/ledger_canister/src/account_identifier.rs]
+    const byteArray = wordArrayToByteArray(hash, 28);
+    const checksum = generateChecksum(new Uint8Array(byteArray));
+    const val = checksum + hash.toString();
+  
+    return val;
+  };

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,0 +1,60 @@
+/* eslint-disable no-prototype-builtins */
+/* eslint-disable no-bitwise */
+import crc32 from 'buffer-crc32';
+import CryptoJS from 'crypto-js';
+
+export const byteArrayToWordArray = (byteArray: Uint8Array) => {
+  const wordArray = [] as any;
+  let i;
+  for (i = 0; i < byteArray.length; i += 1) {
+    wordArray[(i / 4) | 0] |= byteArray[i] << (24 - 8 * i);
+  }
+  // eslint-disable-next-line
+  const result = CryptoJS.lib.WordArray.create(
+    wordArray,
+    byteArray.length
+  );
+  return result;
+};
+
+export const wordToByteArray = (word, length): number[] => {
+  const byteArray: number[] = [];
+  const xFF = 0xff;
+  if (length > 0) byteArray.push(word >>> 24);
+  if (length > 1) byteArray.push((word >>> 16) & xFF);
+  if (length > 2) byteArray.push((word >>> 8) & xFF);
+  if (length > 3) byteArray.push(word & xFF);
+
+  return byteArray;
+};
+
+export const wordArrayToByteArray = (wordArray, length) => {
+  if (
+    wordArray.hasOwnProperty('sigBytes') &&
+    wordArray.hasOwnProperty('words')
+  ) {
+    length = wordArray.sigBytes;
+    wordArray = wordArray.words;
+  }
+
+  let result: number[] = [];
+  let bytes;
+  let i = 0;
+  while (length > 0) {
+    bytes = wordToByteArray(wordArray[i], Math.min(4, length));
+    length -= bytes.length;
+    result = [...result, bytes];
+    i++;
+  }
+  return ([] as number[]).concat.apply([], result);
+};
+
+export const intToHex = (val: number) =>
+  val < 0 ? (Number(val) >>> 0).toString(16) : Number(val).toString(16);
+
+// We generate a CRC32 checksum, and trnasform it into a hexString
+export const generateChecksum = (hash: Uint8Array) => {
+  const crc = crc32.unsigned(Buffer.from(hash));
+  const hex = intToHex(crc);
+  return hex.padStart(8, '0');
+};

--- a/src/utils/sign.ts
+++ b/src/utils/sign.ts
@@ -1,6 +1,6 @@
 import { IDL, JsonValue } from "@dfinity/candid";
 import { Buffer } from "buffer/";
-import { Transaction } from "../Provider";
+import { Transaction } from "../Provider/interfaces";
 import { recursiveParseBigint } from "./bigint";
 import getDomainMetadata from "./domain-metadata";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1255,6 +1255,11 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-crc32@^0.2.13:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
+
 buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -1574,6 +1579,11 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+crypto-js@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
+  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
 
 cssom@^0.4.4:
   version "0.4.4"


### PR DESCRIPTION
## Changes
- Added principal and accountId as strings in provider interface. 
- Made agent, principal and accountId generate always on connect (even if no whitelist is provided). 
- Removed value from balance call