### PR TITLE
Fix: serialize host in create actor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psychedelic/plug-inpage-provider",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "main": "dist/src/index.js",
   "module": "dist/esm/src/index.js",
   "jsnext:main": "dist/esm/src/index.js",

--- a/src/Provider/index.ts
+++ b/src/Provider/index.ts
@@ -69,11 +69,12 @@ export default class Provider implements ProviderInterface {
       throw Error("interfaceFactory is a required argument");
     const metadata = getDomainMetadata();
     this.idls[canisterId] = getArgTypes(interfaceFactory);
+    const connectionData = await this.sessionManager.getConnectionData();
     if (!this.agent) {
       this.agent = await createAgent(
         this.clientRPC,
         metadata,
-        { whitelist: [canisterId] },
+        { whitelist: [canisterId], host: connectionData?.connection?.host },
         this.idls
       );
     }


### PR DESCRIPTION
## Summary
Added call to `getConnectionData` in order to fetch the host indicated in requestConnect