### PR TITLE
Feature: Update provider on account switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psychedelic/plug-inpage-provider",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "main": "dist/src/index.js",
   "module": "dist/esm/src/index.js",
   "jsnext:main": "dist/esm/src/index.js",

--- a/src/Provider/index.ts
+++ b/src/Provider/index.ts
@@ -57,6 +57,7 @@ export default class Provider implements ProviderInterface {
       this.principalId = sessionData?.principalId;
       this.accountId = sessionData?.accountId;
     }
+    this.hookToWindowEvents();
   }
 
   public async createActor<T>({
@@ -299,5 +300,17 @@ export default class Provider implements ProviderInterface {
         queryTransform: transformOverrideHandler,
       },
     });
+  }
+
+  private hookToWindowEvents = () => {
+    window.addEventListener('updateProvider', () => {
+      console.log('reached provider');
+      this.sessionManager.getConnectionData().then((data) => {
+        if (data?.connection) {
+          console.log('Provider connection updated correctly', data);
+          // window.postMessage({action: 'GOT_DUCK', payload: 'duck'}, '*');
+        }
+      });
+   }, false);
   }
 }

--- a/src/Provider/index.ts
+++ b/src/Provider/index.ts
@@ -303,14 +303,8 @@ export default class Provider implements ProviderInterface {
   }
 
   private hookToWindowEvents = () => {
-    window.addEventListener('updateProvider', () => {
-      console.log('reached provider');
-      this.sessionManager.getConnectionData().then((data) => {
-        if (data?.connection) {
-          console.log('Provider connection updated correctly', data);
-          // window.postMessage({action: 'GOT_DUCK', payload: 'duck'}, '*');
-        }
-      });
+    window.addEventListener('updateConnection', () => {
+      this.sessionManager.updateConnection();
    }, false);
   }
 }

--- a/src/Provider/interfaces.ts
+++ b/src/Provider/interfaces.ts
@@ -1,6 +1,7 @@
 import { Agent, HttpAgent, ActorSubclass } from "@dfinity/agent";
 import { IDL } from "@dfinity/candid";
 import { Principal } from "@dfinity/principal";
+import { ConnectionData } from "../modules/SessionManager";
 
 import { CreateAgentParams } from "../utils/agent";
 
@@ -71,6 +72,7 @@ export interface RequestBurnXTCParams {
   
 export interface RequestConnectParams extends CreateAgentParams {
   timeout?: number;
+  onConnectionUpdate?: (data: ConnectionData) => any;
 }
   
 export interface ProviderInterfaceVersions {

--- a/src/modules/SessionManager/index.ts
+++ b/src/modules/SessionManager/index.ts
@@ -8,7 +8,7 @@ import { privateCreateAgent } from "../../utils/agent";
 import { HttpAgent, PublicKey } from "@dfinity/agent";
 
 type SessionData = { agent: HttpAgent, principalId: string, accountId: string } | null;
-type ConnectionData = {
+export type ConnectionData = {
   sessionData: SessionData,
   connection: RequestConnectParams & { publicKey: PublicKey }
 };
@@ -27,6 +27,7 @@ export default class SessionManager {
   private rpc: RPCManager;
   private sessionData: SessionData = null;
   private initialized: boolean = false;
+  private onConnectionUpdate?: (data: ConnectionData) => any;
 
   constructor({ host, whitelist, timeout, rpc }: SessionManagerOptions) {
     this.host = host || IC_MAINNET_URLS[0];
@@ -95,6 +96,7 @@ export default class SessionManager {
     this.host = host;
     this.whitelist = whitelist;
     this.timeout = timeout;
+    this.onConnectionUpdate = args?.onConnectionUpdate;
     const sessionData = await this.createSession(publicKey);
     return { sessionData, connection: { host, whitelist, timeout, publicKey } };
   }
@@ -107,6 +109,13 @@ export default class SessionManager {
       args: [metadata.url],
     });
     this.sessionData = null;
+  }
+
+  public async updateConnection() {
+    const data = await this.getConnectionData();
+    if (data) {
+      this.onConnectionUpdate?.(data);
+    }
   }
 
 };


### PR DESCRIPTION
## Summary
Built new communication layer for provider **incoming** connections. 

## Changelist
- Sets up port communication with extension content script
- Adds `onConnectionUpdate` callback parameter for `requestConnect`, triggered on provider session update
- Added update hook to allow extension to request a provider update by calling `getConnectionData`, eliminating the  threat of an external agent modifying the state.