### PR TITLE
Fix: Url serialization in requestQuery and requestReadState

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psychedelic/plug-inpage-provider",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "main": "dist/src/index.js",
   "module": "dist/esm/src/index.js",
   "jsnext:main": "dist/esm/src/index.js",

--- a/src/Provider/interfaces.ts
+++ b/src/Provider/interfaces.ts
@@ -63,6 +63,7 @@ export interface CreateActor<T> {
   actor: ActorSubclass<ActorSubclass<T>>;
   canisterId: string;
   interfaceFactory: IDL.InterfaceFactory;
+  host?: string;
 }
   
 export interface RequestBurnXTCParams {

--- a/src/utils/factories/agent.ts
+++ b/src/utils/factories/agent.ts
@@ -78,6 +78,7 @@ export const queryMethodFactory =
           canisterId: canisterId.toString(),
           methodName: fields.methodName,
           arg: bufferToBase64(Buffer.from(blobToUint8Array(fields.arg).buffer)),
+          url: getDomainMetadata().url,
         },
       ],
     });
@@ -116,6 +117,7 @@ export const readStateMethodFactory =
           {
             canisterId: canisterId.toString(),
             paths,
+            url: getDomainMetadata().url,
           },
         ],
       });


### PR DESCRIPTION
# Summary
Added url serialization to be able to get the host on readState and query methods